### PR TITLE
Patch DIVA for CPU-based local reproduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+diva_env/
+__pycache__/
+*.pyc
+dataset/MNIST/
+*.model
+paper_experiments/rotated_mnist/dataset/MNIST/

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -101,3 +101,5 @@ http://yann.lecun.com/exdb/mnist/
 This failed with HTTP 404.
 
 Temporary local fix was made inside the virtual environment’s torchvision MNIST file by replacing URLs with:
+
+https://ossci-datasets.s3.amazonaws.com/mnist/

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -71,4 +71,24 @@ MNIST is downloaded into: paper_experiments/rotated_mnist/dataset/MNIST/
 
 This folder is ignored by Git.
 
+The repo already contains supervised index files:
+
+paper_experiments/rotated_mnist/dataset/supervised_inds_0.npy
+
+paper_experiments/rotated_mnist/dataset/supervised_inds_1.npy
+
 ## Local Compatibility Fixes Already Made
+
+1. CPU compatibility in model_diva.py
+
+Original code assumed CUDA and used .cuda() directly.
+
+Local fix:
+Use device-aware logic.
+
+Example:
+
+self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+and replace hardcoded CUDA tensors with:
+.to(self.device)

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -18,6 +18,8 @@ Use:
 
 bash
 git checkout baseline-diva
+
 Windows path: C:\Users\raeda\Documents\research\PhD\DIVA-REPRODUCTION
+
 Git Bash Path: ~/Documents/research/PhD/DIVA-REPRODUCTION
  

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -1,0 +1,23 @@
+# DIVA Reproduction Quick Start
+
+## Project
+Forked repo:
+
+https://github.com/Ndiatenda/DIVA-REPRODUCTION
+
+Original repo:
+
+https://github.com/AMLab-Amsterdam/DIVA
+
+Current purpose:
+Reproduce the DIVA rotated-MNIST experiments first, then analyse the latent representations and later introduce structured/dependence-based extensions for PhD work.
+
+## Current Branch
+
+Use:
+
+bash
+git checkout baseline-diva
+Windows path: C:\Users\raeda\Documents\research\PhD\DIVA-REPRODUCTION
+Git Bash Path: ~/Documents/research/PhD/DIVA-REPRODUCTION
+ 

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -59,3 +59,6 @@ PyTorch 1.0.1 was originally targeted but was not installable easily on this Win
 cd paper_experiments/rotated_mnist/supervised
 
 PYTHONPATH=../../.. python experiment_only_sup_diva.py
+
+Important: run from inside the supervised experiment folder.
+

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -62,3 +62,5 @@ PYTHONPATH=../../.. python experiment_only_sup_diva.py
 
 Important: run from inside the supervised experiment folder.
 
+Reason:
+The script uses old relative paths such as: ../../dataset/

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -16,10 +16,12 @@ Reproduce the DIVA rotated-MNIST experiments first, then analyse the latent repr
 
 Use:
 
-bash
 git checkout baseline-diva
 
 Windows path: C:\Users\raeda\Documents\research\PhD\DIVA-REPRODUCTION
 
 Git Bash Path: ~/Documents/research/PhD/DIVA-REPRODUCTION
- 
+
+Activate environment: source diva_env/Scripts/activate
+
+

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -50,3 +50,5 @@ seaborn: 0.9.0
 scikit-image: 0.14.1
 scikit-learn: 0.19.1
 
+Note:
+PyTorch 1.0.1 was originally targeted but was not installable easily on this Windows/Python setup. PyTorch 1.7.0+cpu was used for local smoke testing.

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -71,8 +71,4 @@ MNIST is downloaded into: paper_experiments/rotated_mnist/dataset/MNIST/
 
 This folder is ignored by Git.
 
-The repo already contains supervised index files: 
-paper_experiments/rotated_mnist/dataset/supervised_inds_0.npy
-
-paper_experiments/rotated_mnist/dataset/supervised_inds_1.npy
-...
+## Local Compatibility Fixes Already Made

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -24,4 +24,29 @@ Git Bash Path: ~/Documents/research/PhD/DIVA-REPRODUCTION
 
 Activate environment: source diva_env/Scripts/activate
 
+Check Python Version: python --version 
+
+Python 3.6.8 expected
+
+Check Pytorch: python -c "import torch; print(torch.__version__); print(torch.cuda.is_available())"
+
+1.7.0+cpu
+False  Expected 
+
+#Key Installed Versions:
+
+Python: 3.6.8
+
+PyTorch: 1.7.0+cpu
+
+torchvision: 0.8.1+cpu
+
+numpy: 1.19.5
+
+matplotlib: 3.4
+
+seaborn: 0.9.0
+
+scikit-image: 0.14.1
+scikit-learn: 0.19.1
 

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -48,7 +48,14 @@ matplotlib: 3.4
 seaborn: 0.9.0
 
 scikit-image: 0.14.1
+
 scikit-learn: 0.19.1
 
 Note:
 PyTorch 1.0.1 was originally targeted but was not installable easily on this Windows/Python setup. PyTorch 1.7.0+cpu was used for local smoke testing.
+
+## Run Supervised Rotated MNIST Experiment
+
+cd paper_experiments/rotated_mnist/supervised
+
+PYTHONPATH=../../.. python experiment_only_sup_diva.py

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -92,3 +92,12 @@ self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 and replace hardcoded CUDA tensors with:
 .to(self.device)
+
+2. MNIST URL fix
+
+Old torchvision attempted to download from:
+http://yann.lecun.com/exdb/mnist/
+
+This failed with HTTP 404.
+
+Temporary local fix was made inside the virtual environment’s torchvision MNIST file by replacing URLs with:

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -64,3 +64,15 @@ Important: run from inside the supervised experiment folder.
 
 Reason:
 The script uses old relative paths such as: ../../dataset/
+
+## Dataset
+
+MNIST is downloaded into: paper_experiments/rotated_mnist/dataset/MNIST/
+
+This folder is ignored by Git.
+
+The repo already contains supervised index files: 
+paper_experiments/rotated_mnist/dataset/supervised_inds_0.npy
+
+paper_experiments/rotated_mnist/dataset/supervised_inds_1.npy
+...

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -33,7 +33,7 @@ Check Pytorch: python -c "import torch; print(torch.__version__); print(torch.cu
 1.7.0+cpu
 False  Expected 
 
-#Key Installed Versions:
+## Key Installed Versions:
 
 Python: 3.6.8
 

--- a/notes/00_quick_start.md
+++ b/notes/00_quick_start.md
@@ -103,3 +103,9 @@ This failed with HTTP 404.
 Temporary local fix was made inside the virtual environment’s torchvision MNIST file by replacing URLs with:
 
 https://ossci-datasets.s3.amazonaws.com/mnist/
+
+Important:
+This change is not committed because it was inside diva_env.
+
+Need a cleaner repo-level solution later.
+

--- a/paper_experiments/rotated_mnist/supervised/model_diva.py
+++ b/paper_experiments/rotated_mnist/supervised/model_diva.py
@@ -202,6 +202,7 @@ class qy(nn.Module):
 class DIVA(nn.Module):
     def __init__(self, args):
         super(DIVA, self).__init__()
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.zd_dim = args.zd_dim
         self.zx_dim = args.zx_dim
         self.zy_dim = args.zy_dim
@@ -231,7 +232,9 @@ class DIVA(nn.Module):
         self.beta_x = args.beta_x
         self.beta_y = args.beta_y
 
-        self.cuda()
+        # self.cuda()
+        if torch.cuda.is_available():
+            self.cuda()
 
     def forward(self, d, x, y):
         # Encode
@@ -259,8 +262,10 @@ class DIVA(nn.Module):
         zd_p_loc, zd_p_scale = self.pzd(d)
 
         if self.zx_dim != 0:
-            zx_p_loc, zx_p_scale = torch.zeros(zd_p_loc.size()[0], self.zx_dim).cuda(),\
-                                   torch.ones(zd_p_loc.size()[0], self.zx_dim).cuda()
+            # zx_p_loc, zx_p_scale = torch.zeros(zd_p_loc.size()[0], self.zx_dim).cuda(),\
+            #                        torch.ones(zd_p_loc.size()[0], self.zx_dim).cuda()
+            zx_p_loc = torch.zeros(zd_p_loc.size()[0], self.zx_dim).to(self.device)
+            zx_p_scale = torch.ones(zd_p_loc.size()[0], self.zx_dim).to(self.device)
         zy_p_loc, zy_p_scale = self.pzy(y)
 
         # Reparameterization trick
@@ -297,8 +302,10 @@ class DIVA(nn.Module):
 
             zd_p_loc, zd_p_scale = self.pzd(d)
             if self.zx_dim != 0:
-                zx_p_loc, zx_p_scale = torch.zeros(zd_p_loc.size()[0], self.zx_dim).cuda(), \
-                                       torch.ones(zd_p_loc.size()[0], self.zx_dim).cuda()
+                # zx_p_loc, zx_p_scale = torch.zeros(zd_p_loc.size()[0], self.zx_dim).cuda(), \
+                #                        torch.ones(zd_p_loc.size()[0], self.zx_dim).cuda()
+                zx_p_loc, zx_p_scale = torch.zeros(zd_p_loc.size()[0], self.zx_dim).to(self.device), \
+                                       torch.ones(zd_p_loc.size()[0], self.zx_dim).to(self.device)
 
             pzd = dist.Normal(zd_p_loc, zd_p_scale)
 
@@ -328,7 +335,7 @@ class DIVA(nn.Module):
             # Create labels and repeats of zy_q and qzy
             y_onehot = torch.eye(10)
             y_onehot = y_onehot.repeat(1, 100)
-            y_onehot = y_onehot.view(1000, 10).cuda()
+            y_onehot = y_onehot.view(1000, 10).to(self.device)
 
             zy_q = zy_q.repeat(10, 1)
             zy_q_loc, zy_q_scale = zy_q_loc.repeat(10, 1), zy_q_scale.repeat(10, 1)
@@ -352,7 +359,7 @@ class DIVA(nn.Module):
 
             marginal_zy_p_minus_zy_q = torch.sum(prob_qy * zy_p_minus_zy_q)
 
-            prior_y = torch.tensor(1/10).cuda()
+            prior_y = torch.tensor(1/10).to(self.device)
             prior_y_minus_qy = torch.log(prior_y) - qy.log_prob(y_onehot)
             marginal_prior_y_minus_qy = torch.sum(prob_qy * prior_y_minus_qy)
 


### PR DESCRIPTION
- Python 3.6.8
- torch 1.7.0+cpu
- torchvision 0.8.1
- need to patch torchvision MNIST URL
- required run command
- CPU compatibility modifications

Run from:
paper_experiments/rotated_mnist/supervised

Command:
PYTHONPATH=../../.. python experiment_only_sup_diva.py